### PR TITLE
ci: pinact CIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: "pnpm"

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -27,12 +27,7 @@ jobs:
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Check all actions are pinned to commit SHA
         run: |
-          FILES=$(find .github/workflows -name *.yml -o -name *.yaml 2>/dev/null; find .github/actions -name action.yml 2>/dev/null)
-          if [ -z "$FILES" ]; then
-            echo "No workflow or action files found"
-            exit 0
-          fi
-          if ! echo "$FILES" | xargs pinact run --check; then
+          if ! pinact run --check --exclude "^flyle-io/shared-actions"; then
             echo "::error::Some actions are not pinned to a commit SHA. Run: pinact run -u --min-age 7"
             exit 1
           fi
@@ -40,11 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify pinned actions
         run: |
-          FILES=$(find .github/workflows -name *.yml -o -name *.yaml 2>/dev/null; find .github/actions -name action.yml 2>/dev/null)
-          if [ -z "$FILES" ]; then
-            exit 0
-          fi
-          if ! echo "$FILES" | xargs pinact run --verify; then
+          if ! pinact run --verify --exclude "^flyle-io/shared-actions"; then
             echo "::error::Some pinned actions have mismatched SHA and version. Run: pinact run -u --min-age 7"
             exit 1
           fi
@@ -60,7 +51,7 @@ jobs:
 
           grep -rh 'uses:' .github/workflows/ .github/actions/ 2>/dev/null \
             | grep -oE '[^@[:space:]]+@[a-f0-9]{40}\s+#\s+\S+' \
-            | sort -u > "$RUNNER_TEMP/actions.txt"
+            | sort -u > "$RUNNER_TEMP/actions.txt" || true
 
           while IFS= read -r line; do
             ACTION=$(echo "$line" | sed 's/@.*//')
@@ -78,8 +69,8 @@ jobs:
           done < "$RUNNER_TEMP/actions.txt"
 
           if [ "$ERRORS" = "1" ]; then
+            echo "::error::Run: pinact run -u --min-age ${MIN_AGE_DAYS}"
             exit 1
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,85 @@
+name: pinact
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/workflows/pinact.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    name: pinact
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install pinact
+        run: |
+          curl -sSfL "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_linux_amd64.tar.gz" \
+            | tar xz -C "$RUNNER_TEMP" pinact
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+      - name: Check all actions are pinned to commit SHA
+        run: |
+          FILES=$(find .github/workflows -name *.yml -o -name *.yaml 2>/dev/null; find .github/actions -name action.yml 2>/dev/null)
+          if [ -z "$FILES" ]; then
+            echo "No workflow or action files found"
+            exit 0
+          fi
+          if ! echo "$FILES" | xargs pinact run --check; then
+            echo "::error::Some actions are not pinned to a commit SHA. Run: pinact run -u --min-age 7"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify pinned actions
+        run: |
+          FILES=$(find .github/workflows -name *.yml -o -name *.yaml 2>/dev/null; find .github/actions -name action.yml 2>/dev/null)
+          if [ -z "$FILES" ]; then
+            exit 0
+          fi
+          if ! echo "$FILES" | xargs pinact run --verify; then
+            echo "::error::Some pinned actions have mismatched SHA and version. Run: pinact run -u --min-age 7"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for recently released actions
+        shell: bash
+        run: |
+          set -euo pipefail
+          MIN_AGE_DAYS=7
+          CUTOFF=$(date -u -d "-${MIN_AGE_DAYS} days" +%s)
+          ERRORS=0
+
+          grep -rh 'uses:' .github/workflows/ .github/actions/ 2>/dev/null \
+            | grep -oE '[^@[:space:]]+@[a-f0-9]{40}\s+#\s+\S+' \
+            | sort -u > "$RUNNER_TEMP/actions.txt"
+
+          while IFS= read -r line; do
+            ACTION=$(echo "$line" | sed 's/@.*//')
+            TAG=$(echo "$line" | sed 's/.*#\s*//')
+            OWNER_REPO=$(echo "$ACTION" | cut -d/ -f1,2)
+
+            PUBLISHED=$(gh api "repos/${OWNER_REPO}/releases/tags/${TAG}" --jq '.published_at // empty' 2>/dev/null || echo "")
+            if [ -z "$PUBLISHED" ] || ! PUBLISHED_TS=$(date -u -d "$PUBLISHED" +%s 2>/dev/null); then
+              continue
+            fi
+            if [ "$PUBLISHED_TS" -gt "$CUTOFF" ]; then
+              echo "::error::${OWNER_REPO}@${TAG} was released on ${PUBLISHED}, which is less than ${MIN_AGE_DAYS} days ago."
+              ERRORS=1
+            fi
+          done < "$RUNNER_TEMP/actions.txt"
+
+          if [ "$ERRORS" = "1" ]; then
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm update:version
           publish: pnpm release


### PR DESCRIPTION
## Summary

- `.github/workflows/pinact.yaml` を追加
- pinactを直接インストールしてCIで以下を検証:
  - 全アクションがコミットSHAにピン留めされているか (`pinact run --check`)
  - SHAとバージョンタグの整合性 (`pinact run --verify`)
  - リリースから7日未満のバージョンが使われていないか